### PR TITLE
edit_automatic-updating

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,7 @@
-$(function() {
+$(document).on('turbolinks:load', function() {
   function buildHTML(message) {
-    var content = message.content ? `${ message.content }` : "";
-    var img = message.image ? `<img src= ${ message.image }>` : "";
+    var content = message.content ? `${ message.content }` : ``;
+    var img = (message.image) ? `<img src= "${ message.image }">` : ``;
     var html = `<div class="message" data-id="${message.id}">
                   <div class="upper-message">
                     <p class="upper-message__username">
@@ -16,17 +16,17 @@ $(function() {
                       ${content}
                     </p>
                       ${img}
-                  </div>
+                  </div>ß
                 </div>`
   return html;
   }
 
+  // メッセージ送信非同期
   $('#new_message').on('submit', function(e){
     e.preventDefault();
 
     var formData = new FormData(this);
     var url = $(this).attr('action')
-
     $.ajax({
       url: url,
       type: "POST",
@@ -41,7 +41,6 @@ $(function() {
       $('.messages').append(html);
       $('#new_message')[0].reset();
       $('.form__submit').prop('disabled', false);
-
         var target = $('.message').last();
         var position = target.offset().top + $('.messages').scrollTop();
         $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
@@ -50,6 +49,39 @@ $(function() {
       alert('メッセージを入力してください')
       $('.form__submit').prop('disabled', false);
     })
-
   })
+
+  // 自動更新
+  $(function(){
+    var reloadMessages = function () {
+      if (window.location.href.match(/\/groups\/\d+\/messages/)){
+        var last_message_id = $('.message:last').data("message-id");
+        // var group_id = $(".group").data("group-id");
+        console.log(last_message_id); 
+
+        $.ajax({ 
+          url: "api/messages", 
+          type: 'get', 
+          dataType: 'json', 
+          data: {last_id: last_message_id} 
+        })
+        .done(function (messages) { 
+          // console.log(messages);
+          var insertHTML = '';
+          if(messages.length != 0){
+            messages.forEach(function (message) {
+            insertHTML = buildHTML(message); 
+            $('.messages').append(insertHTML);
+          })
+          $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+        }
+        })
+        .fail(function () {
+          // console.log('error');
+          alert('自動更新に失敗しました');
+        });
+      };
+    };
+    setInterval(reloadMessages, 5000);
+  });
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -56,7 +56,6 @@ $(document).on('turbolinks:load', function() {
     var reloadMessages = function () {
       if (window.location.href.match(/\/groups\/\d+\/messages/)){
         var last_message_id = $('.message:last').data("message-id");
-        // var group_id = $(".group").data("group-id");
         console.log(last_message_id); 
 
         $.ajax({ 
@@ -66,7 +65,6 @@ $(document).on('turbolinks:load', function() {
           data: {last_id: last_message_id} 
         })
         .done(function (messages) { 
-          // console.log(messages);
           var insertHTML = '';
           if(messages.length != 0){
             messages.forEach(function (message) {
@@ -77,7 +75,6 @@ $(document).on('turbolinks:load', function() {
         }
         })
         .fail(function () {
-          // console.log('error');
           alert('自動更新に失敗しました');
         });
       };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -16,7 +16,7 @@ $(document).on('turbolinks:load', function() {
                       ${content}
                     </p>
                       ${img}
-                  </div>ß
+                  </div>
                 </div>`
   return html;
   }

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -40,7 +40,7 @@ $(document).on('turbolinks:load',function(){
         })
       }
       else {
-        var html = appendNot("一致するワードがありません")
+        var html = appendNot("一致するワードがありません");
         $(`#user-search-result`).append(html);
       }
       })
@@ -51,7 +51,7 @@ $(document).on('turbolinks:load',function(){
 
     $(document).on("click",".user-search-add", function(users){
         var id = $(this).data('user-id');
-        var name = $(this).data("user-name")
+        var name = $(this).data("user-name");
         addUser(id,name);
         $(this).parent().remove();
     })

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,14 @@
+# class Api::MessagesController < ApplicationController
+#   def index
+#     group = Group.find(params[:group_id])
+#     last_message_id = params[:last_id].to_i
+#     @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+#   end
+# end
+
+class Api::MessagesController < ApplicationController
+  def index
+    @group = Group.find(params[:group_id])
+    @messages = @group.messages.includes(:user).where('id > ?', params[:last_id])
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,11 +1,3 @@
-# class Api::MessagesController < ApplicationController
-#   def index
-#     group = Group.find(params[:group_id])
-#     last_message_id = params[:last_id].to_i
-#     @messages = group.messages.includes(:user).where("id > #{last_message_id}")
-#   end
-# end
-
 class Api::MessagesController < ApplicationController
   def index
     @group = Group.find(params[:group_id])

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -28,7 +28,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name, :name, user_ids: []  )
+    params.require(:group).permit(:name, user_ids: []  )
   end
 
   def set_group

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,6 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      # redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
       respond_to do |format|
         format.html  { redirect_to group_messages_path(params[:group_id]), notice: 'メッセージが送信されました' }
         format.json

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content      message.content
+  json.image        message.image.url
+  json.date         message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name    message.user.name
+  json.id           message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id": "#{message.id}"}
   .upper-message
     .upper-message__username
       = message.user.name
@@ -8,4 +8,4 @@
     - if message.content.present?
       %p.sub-message__content
         = message.content
-      = image_tag message.image.url, class: 'sub-message__image' if message.image.present?
+    = image_tag message.image.url, class: 'sub-message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,6 @@
-json.id      @message.id
-json.content @message.content 
-json.date    @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.content @message.content
+json.image @message.image.url
+json.created_at @message.created_at
 json.user_name @message.user.name
-json.image   @message.image.url
+json.id @message.id
+json.date  @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,6 +1,6 @@
-json.content @message.content
-json.image @message.image.url
-json.created_at @message.created_at
-json.user_name @message.user.name
-json.id @message.id
-json.date  @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.content      @message.content
+json.image        @message.image.url
+json.created_at   @message.created_at
+json.user_name    @message.user.name
+json.id           @message.id
+json.date         @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module ChatSpace
       g.helper false
       g.test_framework false
       config.i18n.default_locale = :ja
+      config.time_zone = 'Tokyo'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
## WHAT
グループ内メッセージの自動更新実装

- グルーブ画面にいる時のみ適用
- 毎5秒で非同期通信で更新
- 画像、コメント共に適用

## WHY
リロード等ページの再読み込み（HTMLのリクエスト）をしなくても
最新メッセージの表示を可能にする為。

※該当挙動gif
https://gyazo.com/5c9d214e71f946c24fc980d59b928e52
https://gyazo.com/614dd4f12e6845dd020db2951760d628